### PR TITLE
Remove deprecated Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Festivus
 
-[![Build Status](https://travis-ci.com/festivus-es/festivus.svg?branch=master)](https://travis-ci.com/festivus-es/festivus)
-
 - https://festivus-es.github.io/festivus/Espa%C3%B1a/Andaluc%C3%ADa/Sevilla/festivus.ics
 - https://festivus-es.github.io/festivus/Espa%C3%B1a/Catalu%C3%B1a/Barcelona/festivus.ics
 - https://festivus-es.github.io/festivus/Espa%C3%B1a/Comunidad%20de%20Madrid/Madrid/festivus.ics


### PR DESCRIPTION
We now use GitHub Actions